### PR TITLE
Fix: use a POST request to submit user ID

### DIFF
--- a/eboxbw/eboxbw.py
+++ b/eboxbw/eboxbw.py
@@ -181,11 +181,15 @@ class UsageInfo:
 
 
 def _download_page(id):
-    fmt = 'http://consocable.electronicbox.net/index.php?actions=list&lng=en&code={}'
-    url = fmt.format(id)
+    url = 'http://conso.electronicbox.net/index.php'
+    payload = {
+        'actions': 'list',
+        'lng': 'en',
+        'code': id,
+    }
 
     try:
-        resp = requests.get(url, timeout=15)
+        resp = requests.post(url, timeout=15, data=payload)
     except requests.exceptions.Timeout:
         raise DownloadError('Timeout')
     except Exception as e:


### PR DESCRIPTION
Electronic Box now require POSTing the user data to get the bandwidth
usage, instead of directly GETting the page, using the ID in the
URL. This commit handles this change, and also the updated bandwidth
usage subdomain in the URL (conso vs. consocable).

Signed-off-by: Antoine Busque abusque@efficios.com
