### PR TITLE
Fix: update URL to reflect domain name change

### DIFF
--- a/eboxbw/eboxbw.py
+++ b/eboxbw/eboxbw.py
@@ -181,7 +181,7 @@ class UsageInfo:
 
 
 def _download_page(id):
-    url = 'http://conso.electronicbox.net/index.php'
+    url = 'http://conso.ebox.ca/index.php'
     payload = {
         'actions': 'list',
         'lng': 'en',


### PR DESCRIPTION
The canonical Electronic Box domain is now `ebox.ca` instead of the
previous `electronicbox.net`. Redirecting from one to the other
prevented the usage data from being read normally. Updating the URL
fixes this issue.

Signed-off-by: Antoine Busque abusque@efficios.com
