### PR TITLE
Fix: handle missing data on first hour of month

### DIFF
--- a/eboxbw/cli.py
+++ b/eboxbw/cli.py
@@ -61,6 +61,10 @@ def _print_error(msg):
     sys.exit(1)
 
 
+def _print_warning(msg):
+    cprint('warning: {}'.format(msg), 'yellow', attrs=['bold'], file=sys.stderr)
+
+
 def _bold(t):
     return colored(t, attrs=['bold'])
 
@@ -128,16 +132,20 @@ def _print_human(usage_info, conv_func, punit, details):
 
     more = ''
 
+    cur_month_usage = usage_info.cur_month_usage
+    date = cur_month_usage.date
+    if date is None:
+        _print_warning('No usage data available yet for current month')
+        return
+
     if usage_info.has_super_off_peak:
         more = ' (effective usage on second row)'
 
     print('{}{}:'.format(_prop('Usage summary'), more))
     print_table_header()
-    cur_month_usage = usage_info.cur_month_usage
     tdl = cur_month_usage.dl_usage
     tul = cur_month_usage.ul_usage
     tcb = cur_month_usage.combined_usage
-    date = cur_month_usage.date
     print_row(date, tdl, tul, tcb, lambda d: d.strftime('%Y-%m'))
     print_table_border()
 

--- a/eboxbw/eboxbw.py
+++ b/eboxbw/eboxbw.py
@@ -316,7 +316,10 @@ def _get_cur_month_usage(soup):
         if day_usage is not None:
             day_usages.append(day_usage)
 
-    date = day_usages[0].date.replace(day=1)
+    try:
+        date = day_usages[0].date.replace(day=1)
+    except IndexError:
+        date = None
 
     return MonthUsage(date, day_usages, dl_qty, ul_qty, cb_qty)
 


### PR DESCRIPTION
Fail more gracefully when no data is present on the page for the first
hour of the first day of the month. This results in a human readable
error message being printed out, rather than an IndexError and a stack
trace.

Fixes #2

Signed-off-by: Antoine Busque abusque@efficios.com
